### PR TITLE
Replace djangogirls path names

### DIFF
--- a/src/docs/local-set-up/venv.mdx
+++ b/src/docs/local-set-up/venv.mdx
@@ -9,13 +9,13 @@ So, let's create a virtual environment (also called a virtualenv). Virtualenv wi
 
 All you need to do is find a directory in which you want to create the virtualenv; your home directory, for example. On Windows, it might look like C:\Users\Name\ (where Name is the name of your login).
 
-NOTE: On Windows, make sure that this directory does not contain accented or special characters; if your username contains accented characters, use a different directory, for example, C:\djangogirls.
+NOTE: On Windows, make sure that this directory does not contain accented or special characters; if your username contains accented characters, use a different directory, for example, C:\codersofcolour.
 
-For this tutorial we will be using a new directory djangogirls from your home directory:
+For this tutorial we will be using a new directory codersofcolour from your home directory:
 
 ```bash
-$ mkdir djangogirls
-$ cd djangogirls
+$ mkdir codersofcolour
+$ cd codersofcolour
 ```
 We will make a virtualenv called myvenv
 ## Windows


### PR DESCRIPTION
It might be less misleading to use codersofcolour (or another chosen string) for the virtualenv, just so it is obvious that this is an arbitrary name.

This is the only place this is referenced in the codebase.