### PR TITLE
Suggested changes for Session 2 - Locally building our website

### DIFF
--- a/src/@rocketseat/gatsby-theme-docs/text/index.mdx
+++ b/src/@rocketseat/gatsby-theme-docs/text/index.mdx
@@ -8,4 +8,4 @@ developers working on [Wagtail CMS](https://wagtail.io/).
 <!-- ![promotional picture](./course-pic.png) -->
 
 ## How to get help
-If you need any help whilst on the course, message us on our [Slack channel](https://app.slack.com/client/T012GHH9HG8/G014CV05EG2/thread/G014CV05EG2-1591108786.000800).
+If you need any help whilst on the course, message us on our [Slack channel](https://codersofcolour.slack.com/messages).

--- a/src/docs/local-set-up/heroku.mdx
+++ b/src/docs/local-set-up/heroku.mdx
@@ -3,6 +3,3 @@
 Sign up for a [Heroku Account](https://signup.heroku.com/).
 
 Install the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli)
-
-<iframe name="Framename" src="https://devcenter.heroku.com/articles/heroku-cli" width="400" height="800" frameborder="0" scrolling="auto" class="frame-area">
-</iframe>

--- a/src/docs/python-intro/modules.mdx
+++ b/src/docs/python-intro/modules.mdx
@@ -24,16 +24,13 @@ import codecs
 
 The most important modules in the Standard Library are:
 
-
-- cgi
-- math
-- os
-- pickle
-- random
-- re
-- socket
-- sys
-- time
-- urllib
-
-
+- [cgi](https://docs.python.org/3/library/cgi.html)
+- [math](https://docs.python.org/3/library/math.html)
+- [os](https://docs.python.org/3/library/os.html)
+- [pickle](https://docs.python.org/3/library/pickle.html)
+- [random](https://docs.python.org/3/library/random.html)
+- [re](https://docs.python.org/3/library/re.html)
+- [socket](https://docs.python.org/3/library/socket.html)
+- [sys](https://docs.python.org/3/library/sys.html)
+- [time](https://docs.python.org/3/library/time.html)
+- [urllib](https://docs.python.org/3/library/urllib.html)

--- a/src/docs/wagtail-intro/Session-4-Setting-up-AWS-for-media-files.mdx
+++ b/src/docs/wagtail-intro/Session-4-Setting-up-AWS-for-media-files.mdx
@@ -140,7 +140,7 @@ Git commit those changes and push them up... if successful your image uploads sh
 
 One final change.
 
-When it comes to running migrations, `./manage.py migrate` for the database changes. We don't want to have to run this manually every time on heroku. So you can add this to your Procfile, really we should be testing this with CI but for now it's ok. Open your Procfile and add the top `release` line you see here.
+When it comes to running migrations, `python manage.py migrate` for the database changes. We don't want to have to run this manually every time on heroku. So you can add this to your Procfile, really we should be testing this with CI but for now it's ok. Open your Procfile and add the top `release` line you see here.
 
 ```bash title=Procfile
 release: python manage.py migrate

--- a/src/docs/wagtail-intro/locally-building-our-website.mdx
+++ b/src/docs/wagtail-intro/locally-building-our-website.mdx
@@ -321,7 +321,7 @@ class BlogPage(Page):
 ```
 
 
-Same again, run`python manage.py makemigrations` and `python manage.py migrate` to create the database changes
+Same again, run `python manage.py makemigrations` and `python manage.py migrate` to create the database changes
 
 **Create a template for blog posts**
 

--- a/src/docs/wagtail-intro/locally-building-our-website.mdx
+++ b/src/docs/wagtail-intro/locally-building-our-website.mdx
@@ -507,7 +507,7 @@ After creating your repo you will see some information:
 
 We'll use this to add to our local repo so we can push code to github
 
-now in the project root, we need to initialize the git repository, and add our first initil commit, and push the code
+now in the project root, we need to initialize the git repository, and add our first initial commit, and push the code
 
 ```bash
 git init

--- a/src/docs/wagtail-intro/locally-building-our-website.mdx
+++ b/src/docs/wagtail-intro/locally-building-our-website.mdx
@@ -86,13 +86,13 @@ python manage.py createsuperuser
 python manage.py runserver
 ```
 
-If everything worked, [http://127.0.0.1:8000](http://127.0.0.1:8000/) will show you a welcome page:
+If everything worked, [http://localhost:8000](http://localhost:8000/) will show you a welcome page:
 
 https://docs.wagtail.io/en/v2.8/_images/tutorial_1.png
 
 ![https://docs.wagtail.io/en/v2.8/_images/tutorial_1.png](https://docs.wagtail.io/en/v2.8/_images/tutorial_1.png)
 
-You can now access the administrative area at [http://127.0.0.1:8000/admin](http://127.0.0.1:8000/admin)
+You can now access the administrative area at [http://localhost:8000/admin](http://localhost:8000/admin)
 
 https://docs.wagtail.io/en/v2.8/_images/tutorial_2.png
 
@@ -132,7 +132,8 @@ The above commands should do the following:
 
 ```bash title=output
 (mysite-venv) kevin@mulder:~/shared/mysite/mysite
-python manage.py makemigrations Migrations for 'home': home/migrations/0003_homepage_body.py
+python manage.py makemigrations
+Migrations for 'home': home/migrations/0003_homepage_body.py
 ...
 ```
 
@@ -161,13 +162,13 @@ python manage.py runserver
 
 > It's a good idea to have two terminal windows open whilest developing
 
-Go to the local site in your browser at 0.0.0.0:8000 or 127.0.0.1, or [localhost:8000](http://localhost:8000/) (depending on local hosts setup)
+Go to the local site in your browser at [localhost:8000](http://localhost:8000/).
 
 From the admin menu select pages > home.
 
-This will land you [http://0.0.0.0:8000/admin/pages/3/](http://0.0.0.0:8000/admin/pages/3/) which is your homepage. If there where child pages they would be listed here. Under the home title click 'edit' to edit the page. (note you can also do this straight from the admin menu by clicking page > then the small pencil icon.)
+This will land you [http://localhost:8000/admin/pages/3/](http://localhost:8000/admin/pages/3/) which is your homepage. If there where child pages they would be listed here. Under the home title click 'edit' to edit the page. (note you can also do this straight from the admin menu by clicking page > then the small pencil icon.)
 
-You should be on [http://0.0.0.0:8000/admin/pages/3/edit/](http://0.0.0.0:8000/admin/pages/3/edit/)
+You should be on [http://localhost:8000/admin/pages/3/edit/](http://localhost:8000/admin/pages/3/edit/)
 
 Add some body text and select publish from the bottom bar.
 
@@ -187,7 +188,7 @@ Edit `home/templates/home/home_page.html` to match (remove it all and replace it
 ```
 
 
-Your homepage title and field should now show on the root page of your local site at 0.0.0.0 / 127.0.0.1
+Your homepage title and field should now show on the root page of your local site at localhost / localhost
 
 ## Create a blog app
 

--- a/src/docs/wagtail-intro/locally-building-our-website.mdx
+++ b/src/docs/wagtail-intro/locally-building-our-website.mdx
@@ -23,8 +23,6 @@ python3 --version
 
 If this does not return a version number or returns a version lower than 3.5, you will need to [install Python 3](https://www.python.org/downloads/).
 
-**Important:** Before installing Wagtail, it is necessary to install the libjpeg and zlib libraries, which provide support for working with JPEG, PNG and GIF images (via the Python Pillow library). The way to do this varies by platform—see [Pillow’s platform-specific installation instructions](https://pillow.readthedocs.org/en/latest/installation.html#external-libraries)
-
 ### Create and activate a virtual environment
 
 We recommend using a virtual environment, which provides an isolated Python environment. This tutorial uses [venv](https://docs.python.org/3/tutorial/venv.html), which is packaged with Python 3.

--- a/src/docs/wagtail-intro/locally-building-our-website.mdx
+++ b/src/docs/wagtail-intro/locally-building-our-website.mdx
@@ -475,6 +475,7 @@ Create a .gitignore file in the project root and add the following
 /docs/_build/
 /.tox/
 /venv
+env
 /node_modules/
 npm-debug.log*
 *.idea/

--- a/src/docs/wagtail-intro/locally-building-our-website.mdx
+++ b/src/docs/wagtail-intro/locally-building-our-website.mdx
@@ -162,7 +162,7 @@ python manage.py runserver
 
 > It's a good idea to have two terminal windows open whilest developing
 
-Go to the local site in your browser at [localhost:8000](http://localhost:8000/).
+Go to the local site in your browser at [http://localhost:8000/admin](http://localhost:8000/admin).
 
 From the admin menu select pages > home.
 
@@ -170,7 +170,7 @@ This will land you [http://localhost:8000/admin/pages/3/](http://localhost:8000/
 
 You should be on [http://localhost:8000/admin/pages/3/edit/](http://localhost:8000/admin/pages/3/edit/)
 
-Add some body text and select publish from the bottom bar.
+Add some body text and in the bottom bar click on the arrow next to "Save Draft" and click "Publish".
 
 ![edit homepage](./edit_home_page.png)
 
@@ -188,7 +188,7 @@ Edit `home/templates/home/home_page.html` to match (remove it all and replace it
 ```
 
 
-Your homepage title and field should now show on the root page of your local site at localhost / localhost
+Your homepage title and field should now show on the root page of your local site at [http://localhost:8000/](http://localhost:8000/).
 
 ## Create a blog app
 
@@ -196,7 +196,7 @@ Your homepage title and field should now show on the root page of your local sit
 >
 >If you find one app is solving two problems, split them into two apps. If you find two apps are so intertwined you could never reuse one without the other, combine them into a single app.
 
-First we need to create the blog app. This is done via the `mange.py` file. It should be created at the site root:
+First we need to create the blog app. This is done via the `manage.py` file. It should be created at the site root:
 
 ```bash
 python manage.py startapp blog

--- a/src/docs/wagtail-intro/locally-building-our-website.mdx
+++ b/src/docs/wagtail-intro/locally-building-our-website.mdx
@@ -449,12 +449,12 @@ wrap the content block in a container div and add the tachyons classes to style 
 </div>
 ```
 
-Add some css styling to your custom css file at `[mysite]/static/css/[mysite].css`
+Add some css styling to your custom css file at `mysite/static/css/mysite.css`
 
 I'm just going to make the body colour grey.
 
 ```css
-body{
+body {
     background: #ccc;
 }
 ```

--- a/src/docs/wagtail-intro/locally-building-our-website.mdx
+++ b/src/docs/wagtail-intro/locally-building-our-website.mdx
@@ -118,11 +118,11 @@ class HomePage(Page):
 
 ### Generate and run the migrations needed
 
-The changes we just made will need to be applied to the database. Here we are adding a body field, so the database needs to be able to store the information we add to the body. We do this using the `./manage.py` file with the two following commands:
+The changes we just made will need to be applied to the database. Here we are adding a body field, so the database needs to be able to store the information we add to the body. We do this using the `manage.py` file with the two following commands:
 
 ```bash
-./manage.py makemigrations
-./manage.py migrate
+python manage.py makemigrations
+python manage.py migrate
 ```
 
 The above commands should do the following:
@@ -132,13 +132,13 @@ The above commands should do the following:
 
 ```bash title=output
 (mysite-venv) kevin@mulder:~/shared/mysite/mysite
-./manage.py makemigrations Migrations for 'home': home/migrations/0003_homepage_body.py
+python manage.py makemigrations Migrations for 'home': home/migrations/0003_homepage_body.py
 ...
 ```
 
-### What is the ./manage.py file and ./migrate?
+### What is the manage.py file and migrate?
 
-The `manage.py` is a python file we use to execute administration tasks. When we run `./manage.py migrate` we are executing the django `migrate` method. This will create automatically create python files that define or adjust database schema. It saves us manually creating tables when we need them.
+The `manage.py` is a python file we use to execute administration tasks. When we run `python manage.py migrate` we are executing the django `migrate` method. This will create automatically create python files that define or adjust database schema. It saves us manually creating tables when we need them.
 
 Migrations are Django’s way of propagating changes you make to your models (adding a field, deleting a model, etc.) into your database schema. They’re designed to be mostly automatic, but you’ll need to know when to make migrations, when to run them, and the common problems you might run into. Read more about migration on the [Django docs](https://docs.djangoproject.com/en/3.0/topics/migrations/)
 
@@ -156,7 +156,7 @@ class HomePage(Page):
 Check your terminal to see if the site is still running, if it isn't, run
 
 ```bash
-./manage.py runserver
+python manage.py runserver
 ```
 
 > It's a good idea to have two terminal windows open whilest developing
@@ -198,7 +198,7 @@ Your homepage title and field should now show on the root page of your local sit
 First we need to create the blog app. This is done via the `mange.py` file. It should be created at the site root:
 
 ```bash
-./manage.py startapp blog
+python manage.py startapp blog
 ```
 
 so your file structure should now be:
@@ -261,7 +261,7 @@ class BlogIndexPage(Page):
 ```
 
 
-Similar to what we did earlier, run `./manage.py makemigrations` and `./manage.py migrate`. This will add define the schema in our database for the blog.
+Similar to what we did earlier, run `python manage.py makemigrations` and `python manage.py migrate`. This will add define the schema in our database for the blog.
 
 After running this, go the the cms admin and add a child page to our homepage:
 
@@ -288,7 +288,7 @@ Make a file at `blog/templates/blog/blog_index_page.html` with this content:
 {% endblock %}
 ```
 
-(Restart the local server if your template isn’t found by ctrl + c then ./manage.py runserver)
+(Restart the local server if your template isn’t found by ctrl + c then python manage.py runserver)
 
 **Add a model for blog posts**
 
@@ -321,7 +321,7 @@ class BlogPage(Page):
 ```
 
 
-Same again, run`./manage.py makemigrations` and `./manage.py migrate` to create the database changes
+Same again, run`python manage.py makemigrations` and `python manage.py migrate` to create the database changes
 
 **Create a template for blog posts**
 
@@ -408,7 +408,7 @@ image = models.ForeignKey(
 ImageChooserPanel('image'),
 ```
 
-Again, because we added a field to hold data... run `./manage.py makemigrations` and `./manage.py migrate`
+Again, because we added a field to hold data... run `python manage.py makemigrations` and `python manage.py migrate`
 
 ### Update the blog post template to output images
 

--- a/src/docs/wagtail-intro/locally-building-our-website.mdx
+++ b/src/docs/wagtail-intro/locally-building-our-website.mdx
@@ -116,7 +116,7 @@ class HomePage(Page):
     body = RichTextField(blank=True)
 ```
 
-Generate and run the migrations needed
+### Generate and run the migrations needed
 
 The changes we just made will need to be applied to the database. Here we are adding a body field, so the database needs to be able to store the information we add to the body. We do this using the `./manage.py` file with the two following commands:
 

--- a/src/docs/wagtail-intro/locally-building-our-website.mdx
+++ b/src/docs/wagtail-intro/locally-building-our-website.mdx
@@ -192,7 +192,7 @@ Your homepage title and field should now show on the root page of your local sit
 
 ## Create a blog app
 
-> An app refers to a submodule in our project. It's self-sufficient and not intertwined with the other apps in the project such that, in theory, you could pick it up and move it down into another project without any modification. An app typically has its own models.py. You might think of it as a standalone python module. A simple project might only have one app, whereas more complex projects or websites will have multiple apps that define deifferent models. E.G a news app defining a NewsPost model, a video app defining a VideoPage model etc.
+> An app refers to a submodule in our project. It's self-sufficient and not intertwined with the other apps in the project such that, in theory, you could pick it up and move it down into another project without any modification. An app typically has its own models.py. You might think of it as a standalone python module. A simple project might only have one app, whereas more complex projects or websites will have multiple apps that define different models. E.G a news app defining a NewsPost model, a video app defining a VideoPage model etc.
 >
 >If you find one app is solving two problems, split them into two apps. If you find two apps are so intertwined you could never reuse one without the other, combine them into a single app.
 
@@ -204,11 +204,11 @@ python manage.py startapp blog
 
 so your file structure should now be:
 ```bash
-tree -L 1
 .
 ├── blog # The blog app we just created
 ├── db.sqlite3
 ├── Dockerfile
+├── env
 ├── home
 ├── manage.py
 ├── mysite
@@ -216,12 +216,11 @@ tree -L 1
 └── search
 ```
 
-To view your file structure like above, type `tree -L 1` if you are using Windows, Mac: `brew install tree` and then `tree -L 1`  Linux: `sudo apt-get install tree -y` followed by `tree -L 1`
+To view your file structure like above, type `dir` if you are using Windows, and `ls` on Mac and Linux.
 
-The startapp command generated an app with some boilerplate files for us:
+The startapp command generated an app with some boilerplate files for us (use `dir blog` or `ls blog` to view the files):
 
 ```bash
-tree blog
 blog
 ├── admin.py
 ├── apps.py

--- a/src/docs/wagtail-intro/locally-building-our-website.mdx
+++ b/src/docs/wagtail-intro/locally-building-our-website.mdx
@@ -100,8 +100,6 @@ https://docs.wagtail.io/en/v2.8/_images/tutorial_2.png
 
 ## Development
 
-TODO The following example is for a blog, we should make this more relevant, like donation page or something
-
 ### Edit the homepage model
 
 Out of the box, the “home” app defines a blank `HomePage` model in [`models.py`](http://models.py/), along with a migration that creates a homepage and configures Wagtail to use it.

--- a/src/docs/wagtail-intro/locally-building-our-website.mdx
+++ b/src/docs/wagtail-intro/locally-building-our-website.mdx
@@ -336,7 +336,7 @@ Make a file at `blog/templates/blog/blog_page.html` with this content:
     <p class="meta">{{ page.date }}</p>
     <div class="intro">{{ page.intro }}</div>
     {{ page.body|richtext }}
-    <p><a href="{{ page.get_parent.url }}">Return to blog</a></p>
+    <p><a href="{% pageurl page.get_parent %}">Return to blog</a></p>
 {% endblock %}
 ```
 
@@ -421,7 +421,7 @@ Again, because we added a field to hold data... run `python manage.py makemigrat
     {% image page.image fill-320x320 %}
     <div class="intro">{{ page.intro }}</div>
         {{ page.body|richtext }}
-    <p><a href="{{ page.get_parent.url }}">Return to blog</a></p>
+    <p><a href="{% pageurl page.get_parent %}">Return to blog</a></p>
 {% endblock %}
 ```
 

--- a/src/docs/wagtail-intro/production-and-Deployment.mdx
+++ b/src/docs/wagtail-intro/production-and-Deployment.mdx
@@ -87,7 +87,7 @@ If you click **Open app** now, you'll probably see an error page
 
 ![](./pd_3.png)
 
-This is throwing an error because we haven't ran `./manage,py migrate` on heroku to populate the database. Also remember we specified DEBUG=False in our production settings file? Well we shouldn't be seeing this ugly error screen at all, it's for developers. This is because we haven't told heroku to use our production settings file. Let's fix it.
+This is throwing an error because we haven't ran `python manage,py migrate` on heroku to populate the database. Also remember we specified DEBUG=False in our production settings file? Well we shouldn't be seeing this ugly error screen at all, it's for developers. This is because we haven't told heroku to use our production settings file. Let's fix it.
 
 In heroku go to the settings tab and hit reveal config vars. Add 2 new values:
 

--- a/src/docs/wagtail-intro/wagtail-introduction.mdx
+++ b/src/docs/wagtail-intro/wagtail-introduction.mdx
@@ -5,7 +5,7 @@ We'll
  - **build our site locally**
  - **push it to github**
 and using heroku and AWS we will 
- - **configure a production envoronment for your work to be live and accesible** by anyone in the world.
+ - **configure a production environment for your work to be live and accessible** by anyone in the world.
 
 ## Glossary of systems we will be using
 


### PR DESCRIPTION
Took me quite a bit of time to get through this on Windows but here we go :) I don’t think all of those changes are strictly needed but I hope they will help avoiding confusion / making this easier on Windows in particular.

There are a few things which I would suggest to change but I didn’t do:

- At the start you make us create a `mysite` folder and then do everything else inside it – with the venv command also creating a `mysite` inside of that, and `wagtail start` also creating its own `mysite`. That means there are three folders called the same thing – that’s going to be very confusing for people. Could we rename the first folder to `workshop`, and then the venv one to `codersofcolour`? Since that’s what you name the GitHub repository in the end
- I don’t really see the value in adding normalize.css and Tachyons. The only thing you use it for is to add `padding-left` and `padding-right`, which it would be much nicer to teach them to do in CSS anyway – the Tachyons classes are somewhat meaningless ("ph3").
