### PR TITLE
Suggested changes for Session 3 - Production and Deployment

### DIFF
--- a/src/docs/wagtail-intro/production-and-Deployment.mdx
+++ b/src/docs/wagtail-intro/production-and-Deployment.mdx
@@ -87,7 +87,7 @@ If you click **Open app** now, you'll probably see an error page
 
 ![](./pd_3.png)
 
-This is throwing an error because we haven't ran `python manage,py migrate` on heroku to populate the database. Also remember we specified DEBUG=False in our production settings file? Well we shouldn't be seeing this ugly error screen at all, it's for developers. This is because we haven't told heroku to use our production settings file. Let's fix it.
+This is throwing an error because we haven't ran `python manage.py migrate` on heroku to populate the database. Also remember we specified DEBUG=False in our production settings file? Well we shouldn't be seeing this ugly error screen at all, it's for developers. This is because we haven't told heroku to use our production settings file. Let's fix it.
 
 In heroku go to the settings tab and hit reveal config vars. Add 2 new values:
 
@@ -122,7 +122,7 @@ pip install whitenoise
 pip freeze > requirements.txt
 ```
 
-Now you need to add Whitenoise to your MIDDLEWARE. Open settings/base.py and add whitenoise. Note This MUST go after ...SecurityMiddleware
+Now you need to add Whitenoise to your MIDDLEWARE. Open `settings/base.py` and add whitenoise. Note This MUST go after ...SecurityMiddleware
 
 ```python title=mysite/settings/base.py
 MIDDLEWARE = [
@@ -135,7 +135,7 @@ MIDDLEWARE = [
 
 Now let's change our static file storage type, and some compression settings. Open settings/production.py and add this:
 
-```python lineNumbers=true title=mysite/settings/base.py
+```python lineNumbers=true title=mysite/settings/production.py
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 COMPRESS_OFFLINE = True
 COMPRESS_CSS_FILTERS = [

--- a/src/docs/wagtail-intro/production-and-Deployment.mdx
+++ b/src/docs/wagtail-intro/production-and-Deployment.mdx
@@ -173,8 +173,6 @@ Then click the button below to enable deployments automatically when the master 
 If you sucessfully connected github, just push to the github origin (not heroku), and the app should build.
 
 ```bash
-git add .
-git commit -m "Updates for heroku static files"
 git push origin master
 ```
 


### PR DESCRIPTION
This was much faster than Session 2 – I think we might need to remind attendees to enter content on their site / just try using Wagtail, so they have something a bit more fleshed out to look at.

Couple things I didn’t change:

- `django-toolbelt` also installs `psycopg2` and `dj_database_url`, so in theory we could just install toolbelt and that’s it.
- `django-toolbelt` also installs `gunicorn`, so I don’t see how the "if something breaks, install gunicorn" scenario at the end of the Session 3 content could happen.
- `heroku ps:scale web=1` I don’t see what this is for either, "web=1" is the default from the first deployment with the Procfile