### PR TITLE
Add IAM access to AWS policy for buckup

### DIFF
--- a/src/docs/wagtail-intro/Session-4-Setting-up-AWS-for-media-files.mdx
+++ b/src/docs/wagtail-intro/Session-4-Setting-up-AWS-for-media-files.mdx
@@ -41,7 +41,7 @@ In a new tab, Locate the groups link in the left menu and click Create new group
 
 Group Name: S3 (you can see I already have s3full)
 
-The next screen will ask you to attach a policy. Search for s3 and find AmazonS3FullAccess, tick it and click next step.
+The next screen will ask you to attach a policy. Search for s3 and find `AmazonS3FullAccess`, tick that, do the same for `IAMFullAccess` and then click next step.
 
 When your group is created, switch back to your IAM user tab
 


### PR DESCRIPTION
Buckup cannot create AWS config without some additional permissions.

Full IAM access may be over the top but it is the simplest way to get this configured.